### PR TITLE
Added missing initial value for block occupation

### DIFF
--- a/signal.hxx
+++ b/signal.hxx
@@ -9,7 +9,7 @@ namespace EWRB
     class Signal
     {
         private:
-            bool _block_occupied;
+            bool _block_occupied = false;
             const int _id = -1;
             EWRB::SignalState _current_state = EWRB::SignalState::On;
         public:


### PR DESCRIPTION
Some signal lever indicator lights were not returning to on due to their initial value for `block_occupied` not being `false`.